### PR TITLE
125 admin volunteer list

### DIFF
--- a/web/admin/src/components/NotFound.vue
+++ b/web/admin/src/components/NotFound.vue
@@ -1,14 +1,11 @@
+<script setup>
+</script>
+
 <template>
-  <div>
+  <div class="container">
     <h1>Not Found</h1>
     <p>Sorry, this page does not exist.</p>
   </div>
 </template>
-
-<script>
-export default {
-  name: 'NotFound'
-}
-</script>
 
 <style></style>

--- a/web/admin/src/router/index.js
+++ b/web/admin/src/router/index.js
@@ -48,8 +48,9 @@ const routes = [
     meta: { admin: true}
   },
   {
-    path: '/profile',
+    path: '/profile/:uid?',
     name: 'Profile',
+    props: true,
     component: () => import ('@/views/ProfilePage.vue'),
   },
   {

--- a/web/admin/src/views/ProfilePage.vue
+++ b/web/admin/src/views/ProfilePage.vue
@@ -1,9 +1,8 @@
 <script setup>
-
 </script>
 
 <template>
-<div>
+<div class="container">
    <p>Placeholder for the profile page</p>
 </div>
 </template>

--- a/web/admin/src/views/ProfilePage.vue
+++ b/web/admin/src/views/ProfilePage.vue
@@ -1,8 +1,20 @@
 <script setup>
+import { defineProps } from 'vue'
+import { useAuthUserStore } from '@/stores/authUser'
+
+const props = defineProps({
+  uid: String,
+})
+const user = useAuthUserStore()
+
+if (props.uid === '') {
+ props.uid = user.data.uid
+}
+
 </script>
 
 <template>
 <div class="container">
-   <p>Placeholder for the profile page</p>
+   <p>uid {{ uid }}</p>
 </div>
 </template>

--- a/web/admin/src/views/VolunteersPage.vue
+++ b/web/admin/src/views/VolunteersPage.vue
@@ -11,14 +11,9 @@ onBeforeMount( async () => {
   const pstates = await getDocs(q)
 
   pstates.forEach((prof)=> {
-    console.log(prof.id)
     volunteers.value.push(prof.data())
   })
-  console.log('volunteers='+JSON.stringify(volunteers))
 })
-
-
-
 </script>
 
 <template>

--- a/web/firestore.rules
+++ b/web/firestore.rules
@@ -26,7 +26,7 @@ service cloud.firestore {
     }
 
     match /volunteerprofile/{userid} {
-      allow read, update: if request.auth != null && request.auth.uid == resource.data.userid;
+      allow read, update: if request.auth != null && (request.auth.uid == resource.data.userid || request.auth.token.admin == true);
       allow create: if request.auth != null && request.auth.uid == userid;
     }
 


### PR DESCRIPTION
# Related Issue
for #125 

# Description
Updates the firestore rules so admins can read the volunteer list.
Use logged in user in profile page if no uid.
Move NotFound to composition.
