### PR TITLE
Move the woff workaround to the scss file.

### DIFF
--- a/web/admin/src/main.js
+++ b/web/admin/src/main.js
@@ -9,8 +9,6 @@ import { getAuth, connectAuthEmulator, getIdTokenResult } from "firebase/auth"
 import { getAnalytics } from "firebase/analytics"
 import { getFunctions, connectFunctionsEmulator } from "firebase/functions"
 import { useAuthUserStore } from '@/stores/authUser'
-// TODO: this is a workaround for the vite-sass compiler issue
-import 'bootstrap-icons/font/bootstrap-icons.css'
 import './scss/styles.scss'
 import * as bootstrap from 'bootstrap'
 

--- a/web/admin/src/scss/styles.scss
+++ b/web/admin/src/scss/styles.scss
@@ -1,8 +1,14 @@
+// TODO: this is a workaround for the vite-sass issue of loading the woff files in bootstrap-icons.scss using variables
+@font-face {
+  font-display: block;
+  font-family: "bootstrap-icons";
+  src: url("~bootstrap-icons/font/fonts/bootstrap-icons.woff2?1fa40e8900654d2863d011707b9fb6f2") format("woff2"),
+url("~bootstrap-icons/font/fonts/bootstrap-icons.woff?1fa40e8900654d2863d011707b9fb6f2") format("woff");
+}
+
 @import "~bootstrap/scss/_functions.scss";
 @import "~bootstrap/scss/_variables.scss";
 @import "~bootstrap/scss/_mixins.scss";
-
-
 
 .icon-list {
   padding-left: 0;


### PR DESCRIPTION
# Related Issue
<!-- What issue does this PR close? If it should not close the issue, change the word to 'Addresses' -->
Moves the woff import workaround for Vite which is not expanding the variable interpolation.

# Description
<!-- What does the PR do, add a feature, refactor, fix a bug? -->
Need to reference the woff file directly from our scss instead of loading the css file twice.
