### PR TITLE
Adding release notes for the guest app

### DIFF
--- a/web/app/src/components/PageFooter.vue
+++ b/web/app/src/components/PageFooter.vue
@@ -9,7 +9,7 @@ import { config } from '@/config'
    <li class="list-group-item border border-0"><router-link to="/privacy-policy">Privacy Policy</router-link></li>
    <li class="list-group-item border border-0"><router-link to="/contact"><i class="bi bi-telephone-fill"></i> Contact</router-link></li>
    <li class="list-group-item border border-0"><a href="https://github.com/ncosd/food-pantry-app"><i class="bi bi-github"></i> Made with Food-Pantry-App</a></li>
-   <li class="list-group-item border border-0">{{config.version}}</li>
+   <li class="list-group-item border border-0"><router-link :to='{name:"ReleaseNotes", hash: "#"+config.version}'><i class="bi bi-journal-check"></i> {{config.version}}</router-link></li>
  </ul>
 </footer>
 </template>

--- a/web/app/src/router/index.js
+++ b/web/app/src/router/index.js
@@ -63,6 +63,11 @@ const routes = [
     name: 'Contact',
     component: () => import('../views/ContactPage.vue'),
     meta: config.meta.Contact
+  },
+  {
+    path: '/release-notes/',
+    name: 'ReleaseNotes',
+    component: () => import('@/views/ReleaseNotesPage.vue'),
   }
 ]
 

--- a/web/app/src/views/ReleaseNotesPage.vue
+++ b/web/app/src/views/ReleaseNotesPage.vue
@@ -1,0 +1,57 @@
+<script setup>
+
+</script>
+
+<template>
+<div class="container">
+  <h1>Release Notes</h1>
+  <h2 id="1.9.1">January 2, 2024 - 1.9.1</h2>
+  <ul>
+    <li><a href="https://github.com/ncosd/food-pantry-app/issues/39">#39</a> Add a way for users to verify their email.</li>
+    <li><a href="https://github.com/ncosd/food-pantry-app/issues/171">#171</a> Add sorting to volunteer list page.</li>
+  </ul>
+  <h2 id="1.8.0">December 28, 2023 - 1.8.0</h2>
+  <ul>
+    <li><a href="https://github.com/ncosd/food-pantry-app/issues/239">#239</a> Phone shows daily mode.</li>
+    <li><a href="https://github.com/ncosd/food-pantry-app/issues/253">#253</a> List attending volunteers on the admin schedule window page.</li>
+    <li>Adds unavailability as red to the ColorKey on the calendar page.</li>
+    <li>Username in navbar linked to profile page.</li>
+  </ul>
+  <h2 id="1.7.0">December 27, 2023 - 1.7.0</h2>
+  <ul>
+    <li><a href="https://github.com/ncosd/food-pantry-app/issues/215">#215</a> Create color key for the volunteer window calendar.</li>
+    <li><a href="https://github.com/ncosd/food-pantry-app/issues/240">#240</a> Users should not be able to sign up for past volunteer windows.</li>
+  </ul>
+  <h2 id="1.6.0">December 12, 2023 - 1.6.0</h2>
+  <ul>
+    <li><a href="https://github.com/ncosd/food-pantry-app/issues/212">#212</a> Add User Guide completed</li>
+    <li><a href="https://github.com/ncosd/food-pantry-app/issues/237">#237</a> Show loading spinner when registering</li>
+    <li>Change login to use Vue composition</li>
+  </ul>
+  <h2 id="1.5.0">December 8, 2023 - 1.5.0</h2>
+  <ul>
+    <li>User can select between Dark/Light/Auto theme</li>
+    <li>Updated README.md for running the firebase emulator and vite simultaneously</li>
+    <li>Upgraded to bootstrap 5.3.2 and bootstrap-icons 1.11.1</li>
+    <li>Fixed <a href="https://github.com/ncosd/food-pantry-app/issues/236">#236 Sometimes can't add volunteer window</a></li>
+  </ul>
+  <h2 id="1.4.0">October 13, 2023 - 1.4.0</h2>
+  <ul>
+    <li>Admin - Adds calendar next/prev month to schedule page.</li>
+    <li>Admin - Adds volunteer unavailability dates to the schedule page.</li>
+  </ul>
+  <h2 id="1.3.0">October 11, 2023 - 1.3.0</h2>
+  <ul>
+    <li>Admin - sorting volunteer list by first name.</li>
+    <li>Admin - Change page title to "Volunteer | NCFB".</li>
+    <li>Adds unavailability user guide.</li>
+  </ul>
+  <h2 id="1.2.0">October 4, 2023 - 1.2.0</h2>
+  <ul>
+    <li>Volunteer Unavailability days are displayed on the Calendar page.</li>
+    <li>Calendar page can change months to next/previous.</li>
+    <li>Added Calendar page navbar link.</li>
+    <li>Added release notes page.</li>
+  </ul>
+</div>
+</template>


### PR DESCRIPTION
### Related Issue
Add Release Notes page for the guest app and it closes #246 . 

### Description
It adds a release note link to the version number in the footer of the guest app.

### Testing
Run the app, as the instructions given in the README.md file, and you'll be able to see the link on the version number.

<img width="798" alt="image" src="https://github.com/ncosd/food-pantry-app/assets/140355188/9b5b95fa-9e67-4fbd-b77d-e98adfb206a7">

Takes the version number from config file and creates the URL:
<img width="421" alt="image" src="https://github.com/ncosd/food-pantry-app/assets/140355188/567b91e7-ccb6-42ef-b240-5a3e002d276d">


### Stakeholders
@dherbst could you please take a look?


